### PR TITLE
Keep GH action scheduled builds alive

### DIFF
--- a/.github/workflows/auto-ghpages.yaml
+++ b/.github/workflows/auto-ghpages.yaml
@@ -32,3 +32,6 @@ jobs:
           # The above command will fail if no changes were present, so we ignore
           # that.
           git push
+
+      # prevent GH action from disabling scheduled builds
+      - uses: gautamkrishnar/keepalive-workflow@master


### PR DESCRIPTION
GitHub will suspend the scheduled trigger for GitHub action workflows if
there is no commit in the repository for the past 60 days. The cron based
triggers won't run unless a new commit is made.  We use the Keepalive
Workflow[1] action to commit to make new commits to the repo so that
GH actions won't suspend the builds.

[1] https://github.com/gautamkrishnar/keepalive-workflow